### PR TITLE
Fix compile error

### DIFF
--- a/_lib.scss
+++ b/_lib.scss
@@ -1,7 +1,6 @@
 @function svg-url($svg) {
   // Replace newlines. Can't write it any other way (because sass sucks)
-  $svg: str-replace($svg, "
-", "");
+  $svg: str-replace($svg, "\n", "");
   //  Chunk up string in order to avoid "stack level too deep" error
   $encoded: "";
   $slice: 2000;


### PR DESCRIPTION
The new line character is silently breaking compilation in node-sass 4.11.0. This change addresses the compilation error and presumably will still work with whatever problem it is trying to solve.
